### PR TITLE
Actualizada la versión de PHP de codeception

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@
 The DocuWare PHP SDK is built off of the Platform API that DocuWare provides
 
 API reference can be found by navigating to `{dw_server_base_url}/DocuWare/Platform/Home/UriTemplatesDocumentation`
+
+Updated repository in this fork: https://github.com/oondeo/docuware-php-sdk.git

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,9 @@
   },
   "require": {
     "php": ">=5.6 <9",
-    "ext-curl": "*",
-    "codeception/codeception": "^2.4"
+    "ext-curl": "*"
+  },
+  "require-dev": {
+    "codeception/codeception": "^5.1.2"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     }
   },
   "require": {
-    "php": ">=5.6 <=7.2",
+    "php": ">=5.6 < 9",
     "ext-curl": "*",
     "codeception/codeception": "^2.4"
   }

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     }
   },
   "require": {
-    "php": ">=5.6 <9",
+    "php": ">=5.6 <9.0",
     "ext-curl": "*"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     }
   },
   "require": {
-    "php": ">=5.6 < 9",
+    "php": ">=5.6 <9",
     "ext-curl": "*",
     "codeception/codeception": "^2.4"
   }

--- a/new.txt
+++ b/new.txt
@@ -1,0 +1,1 @@
+New File

--- a/new.txt
+++ b/new.txt
@@ -1,2 +1,0 @@
-New File
-Modified

--- a/new.txt
+++ b/new.txt
@@ -1,1 +1,2 @@
 New File
+Modified

--- a/src/DocuWare/Traits/Common.php
+++ b/src/DocuWare/Traits/Common.php
@@ -54,7 +54,7 @@ trait Common
 
                 foreach($xml->children($namespace, true) as $child) {
 
-                    error_log(print_r($child, true));
+                    //error_log(print_r($child, true));
                     
                     $xml->addChild($label, $child);
 


### PR DESCRIPTION
Se ha cambiado el composer.json para que codeception acepte php 8.2 y se ha añadido solamente en desarrollo